### PR TITLE
feat: support csp compliance

### DIFF
--- a/assets/mods/pwa/service-worker/register.ts
+++ b/assets/mods/pwa/service-worker/register.ts
@@ -1,0 +1,9 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('DOMContentLoaded', function() {
+    const idx = document.getElementById('service-worker-index');
+    if (idx && idx.dataset.src) {
+      navigator.serviceWorker.register(idx.dataset.src);
+      idx.parentNode?.removeChild(idx);
+    }
+  });
+}

--- a/layouts/partials/pwa/assets/sw.html
+++ b/layouts/partials/pwa/assets/sw.html
@@ -67,10 +67,18 @@
 {{- $js := resources.Get "mods/pwa/service-worker/index.ts" }}
 {{/* Compile JS. */}}
 {{- $js = $js | js.Build $options }}
-<script>
-  if ('serviceWorker' in navigator) {
-  window.addEventListener('DOMContentLoaded', function() {
-    navigator.serviceWorker.register('{{ $js.RelPermalink }}');
-  });
-}
-</script>
+<div id="service-worker-index" data-src="{{ $js.RelPermalink }}"></div>
+
+{{- $options = dict
+  "sourceMap" (cond hugo.IsProduction "" "inline")
+  "minify" hugo.IsProduction
+  "target" "es2018"
+  "targetPath" "reg.js"
+}}
+{{- $regJs := resources.Get "mods/pwa/service-worker/register.ts" }}
+{{/* Compile JS. */}}
+{{- $regJs = $regJs | js.Build $options }}
+{{ if hugo.IsProduction }}
+  {{ $regJs = $regJs | fingerprint "sha512" }}
+{{ end }}
+<script src="{{ $regJs.RelPermalink }}" {{ if hugo.IsProduction }}integrity="{{ $regJs.Data.Integrity }}"{{ end }}></script>


### PR DESCRIPTION
...to make the PWA compatible with `Content-Security-Policy` best practice where `script-src: 'unsafe-inline'` is not allowed.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src